### PR TITLE
docs: ドキュメント日本語化 + テンプレート使い方ガイド新規作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,63 @@
-# App Factory Template
+# App Factory テンプレート
 
-Expo SDK 55 + React Native 0.83.4 template with batteries included.
+Expo SDK 55 + React Native 0.83.4 の全部入りテンプレートです。
 
-> **Using this template?** See [TEMPLATE_README.md](TEMPLATE_README.md) for the full setup guide.
+> **このテンプレートを使う方へ** セットアップの手順は [TEMPLATE_README.md](TEMPLATE_README.md) をご覧ください。
 
-## Quick Start
+## クイックスタート
 
 ```bash
-# 1. Create a new repo from this template (GitHub: "Use this template")
-# 2. Clone and run the setup script
+# 1. このテンプレートから新しいリポジトリを作成（GitHub の「Use this template」ボタン）
+# 2. クローンしてセットアップスクリプトを実行
 bash setup.sh
 
-# 3. Start development
+# 3. 開発を始める
 pnpm dev
 ```
 
-## What's Included
+## 含まれているもの
 
-| Category         | Details                                                   |
-| ---------------- | --------------------------------------------------------- |
-| **Framework**    | Expo 55, React Native 0.83.4, New Architecture            |
-| **UI**           | Tamagui v1, React Navigation                              |
-| **State**        | Zustand + persist, React Query                            |
-| **Data**         | expo-sqlite with migration pattern                        |
-| **i18n**         | 19 languages (expo-localization + custom system)          |
-| **Monetization** | RevenueCat (subscriptions), AdMob + UMP (ads)             |
-| **CI/CD**        | GitHub Actions (verify, Maestro smoke, Dependabot)        |
-| **Quality**      | ESLint, Prettier, lint-staged, pre-commit hooks           |
-| **Testing**      | Jest (unit), Maestro (E2E)                                |
-| **Scripts**      | Debug toolkit, dev-start, i18n audit, screenshot pipeline |
-| **EAS**          | Build profiles (dev/preview/production), Submit, Update   |
-| **Docs**         | Diataxis structure, ADR template, PR template             |
+| カテゴリ           | 内容                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| **フレームワーク** | Expo 55, React Native 0.83.4, New Architecture               |
+| **UI**             | Tamagui v1, React Navigation                                 |
+| **状態管理**       | Zustand + persist, React Query                               |
+| **データ**         | expo-sqlite（マイグレーション対応）                          |
+| **多言語対応**     | 19 言語（expo-localization + 独自システム）                  |
+| **収益化**         | RevenueCat（サブスクリプション）、AdMob + UMP（広告）        |
+| **CI/CD**          | GitHub Actions（verify、Maestro smoke、Dependabot）          |
+| **品質管理**       | ESLint, Prettier, lint-staged, pre-commit hooks              |
+| **テスト**         | Jest（ユニット）、Maestro（E2E）                             |
+| **スクリプト**     | デバッグツール、dev-start、i18n 監査、スクショパイプライン   |
+| **EAS**            | ビルドプロファイル（dev/preview/production）、Submit、Update |
+| **ドキュメント**   | Diataxis 構成、ADR テンプレート、PR テンプレート             |
 
-## Environment Variables
+## 環境変数（Environment Variables）
 
-All app-specific values come from `.env`. See `.env.example` for the full list.
+アプリ固有の値はすべて `.env` から読み込みます。一覧は `.env.example` を参照してください。
 
-**Required** (fail fast if missing):
+**必須**（未設定だと起動時にエラー）:
 
 - `APP_NAME`, `APP_SLUG`, `IOS_BUNDLE_IDENTIFIER`, `ANDROID_PACKAGE`
 
-**Optional** (service keys):
+**任意**（サービスキー）:
 
-- AdMob IDs, RevenueCat keys, Sentry DSN, Legal URLs, EAS config
+- AdMob ID、RevenueCat キー、Sentry DSN、利用規約 URL、EAS 設定
 
-## Project Structure
+## プロジェクト構成
 
 ```
-app/              # Expo Router pages (file-based routing)
+app/              # Expo Router ページ（ファイルベースルーティング）
 src/
-  core/           # i18n, debug utilities
-  db/             # SQLite database layer
-  features/       # Vertical feature slices
-  services/       # Business logic services
-  stores/         # Zustand state stores
-  types/          # TypeScript type definitions
-scripts/          # Development & build scripts
-plugins/          # Expo config plugins
-docs/             # Documentation (Diataxis structure)
-__tests__/        # Unit tests
-maestro/          # E2E test flows
+  core/           # i18n、デバッグユーティリティ
+  db/             # SQLite データベース層
+  features/       # 機能ごとの垂直スライス
+  services/       # ビジネスロジックサービス
+  stores/         # Zustand ステートストア
+  types/          # TypeScript 型定義
+scripts/          # 開発・ビルドスクリプト
+plugins/          # Expo 設定プラグイン
+docs/             # ドキュメント（Diataxis 構成）
+__tests__/        # ユニットテスト
+maestro/          # E2E テストフロー
 ```

--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -1,93 +1,93 @@
-# App Factory Template
+# App Factory テンプレート
 
-A batteries-included Expo template for building production-ready mobile apps.
+本番レベルのモバイルアプリをすぐに作り始められる、全部入りの Expo テンプレートです。
 
-## What's Included
+## 含まれているもの
 
-| Category         | Details                                                       |
-| ---------------- | ------------------------------------------------------------- |
-| **Framework**    | Expo SDK 55, React Native 0.83.4, Expo Router v55             |
-| **UI**           | Tamagui v1, Reanimated, Gesture Handler                       |
-| **State**        | Zustand + AsyncStorage persist                                |
-| **Data**         | expo-sqlite with migration pattern                            |
-| **i18n**         | 19 languages, auto-detection, Zustand-based                   |
-| **Monetization** | RevenueCat (IAP), AdMob (ads), UMP consent                    |
-| **CI/CD**        | GitHub Actions (verify, Maestro smoke, Dependabot)            |
-| **Quality**      | ESLint, Prettier, lint-staged, pre-commit hooks               |
-| **Testing**      | Jest (unit), Maestro (E2E)                                    |
-| **Scripts**      | Debug toolkit, dev-start, i18n audit, config check, UMP check |
-| **Screenshots**  | Playwright + Sharp store screenshot pipeline                  |
-| **Docs**         | Diataxis structure (explanation, reference, how-to, ADR)      |
+| カテゴリ               | 内容                                                             |
+| ---------------------- | ---------------------------------------------------------------- |
+| **フレームワーク**     | Expo SDK 55, React Native 0.83.4, Expo Router v55                |
+| **UI**                 | Tamagui v1, Reanimated, Gesture Handler                          |
+| **状態管理**           | Zustand + AsyncStorage による永続化（persist）                   |
+| **データ**             | expo-sqlite（マイグレーション対応）                              |
+| **多言語対応**         | 19 言語、自動検出、Zustand ベース                                |
+| **収益化**             | RevenueCat（アプリ内課金）、AdMob（広告）、UMP 同意管理          |
+| **CI/CD**              | GitHub Actions（verify、Maestro smoke、Dependabot）              |
+| **品質管理**           | ESLint, Prettier, lint-staged, pre-commit hooks                  |
+| **テスト**             | Jest（ユニット）、Maestro（E2E）                                 |
+| **スクリプト**         | デバッグツール、dev-start、i18n 監査、設定チェック、UMP チェック |
+| **スクリーンショット** | Playwright + Sharp によるストア掲載用スクショパイプライン        |
+| **ドキュメント**       | Diataxis 構成（explanation、reference、how-to、ADR）             |
 
-## Quick Start
+## クイックスタート
 
 ```bash
-# 1. Create a new repo from this template (GitHub UI: "Use this template")
+# 1. このテンプレートから新しいリポジトリを作成（GitHub の「Use this template」ボタン）
 
-# 2. Clone and run setup
+# 2. クローンしてセットアップを実行
 git clone https://github.com/YOUR_USER/YOUR_APP.git
 cd YOUR_APP
 bash setup.sh
 
-# 3. Start developing
+# 3. 開発を始める
 pnpm dev
 ```
 
-## Setup Script
+## セットアップスクリプト
 
-`setup.sh` replaces all `{{PLACEHOLDER}}` values:
+`setup.sh` を実行すると、すべての `{{PLACEHOLDER}}` が実際の値に置き換わります。
 
-| Placeholder                 | Description          | Example             |
-| --------------------------- | -------------------- | ------------------- |
-| `{{APP_NAME}}`              | Display name         | `MyApp`             |
-| `{{APP_SLUG}}`              | URL-safe slug        | `myapp`             |
-| `{{ANDROID_PACKAGE}}`       | Android package      | `com.example.myapp` |
-| `{{IOS_BUNDLE_IDENTIFIER}}` | iOS bundle ID        | `com.example.myapp` |
-| `{{APP_SCHEME}}`            | Deep link scheme     | `myapp`             |
-| `{{DESCRIPTION}}`           | One-line description | `A great app`       |
-| `{{EAS_PROJECT_ID}}`        | EAS project ID       | `uuid`              |
+| プレースホルダー            | 説明                   | 例                  |
+| --------------------------- | ---------------------- | ------------------- |
+| `{{APP_NAME}}`              | 表示名                 | `MyApp`             |
+| `{{APP_SLUG}}`              | URL 用スラッグ         | `myapp`             |
+| `{{ANDROID_PACKAGE}}`       | Android パッケージ名   | `com.example.myapp` |
+| `{{IOS_BUNDLE_IDENTIFIER}}` | iOS バンドル ID        | `com.example.myapp` |
+| `{{APP_SCHEME}}`            | ディープリンクスキーム | `myapp`             |
+| `{{DESCRIPTION}}`           | 一行の説明文           | `A great app`       |
+| `{{EAS_PROJECT_ID}}`        | EAS プロジェクト ID    | `uuid`              |
 
-## Key Commands
+## 主なコマンド
 
 ```bash
-pnpm dev              # Start Metro bundler
-pnpm verify           # Run all quality checks
-pnpm dev:android      # ADB check + port forward + Metro
-pnpm test             # Run unit tests
-pnpm test:e2e         # Run Maestro E2E tests
-pnpm i18n:audit       # Find unused/missing i18n keys
-pnpm format:fix       # Auto-format all files
-pnpm debug:start      # Start debug session
-pnpm debug:stop       # Stop and collect debug artifacts
-pnpm monitor          # Real-time crash/error monitor
+pnpm dev              # Metro バンドラーを起動
+pnpm verify           # すべての品質チェックを実行
+pnpm dev:android      # ADB 確認 + ポート転送 + Metro 起動
+pnpm test             # ユニットテストを実行
+pnpm test:e2e         # Maestro E2E テストを実行
+pnpm i18n:audit       # 未使用・不足している i18n キーを検出
+pnpm format:fix       # 全ファイルを自動フォーマット
+pnpm debug:start      # デバッグセッションを開始
+pnpm debug:stop       # デバッグセッションを終了してログを収集
+pnpm monitor          # リアルタイムでクラッシュ・エラーを監視
 ```
 
-## Project Structure
+## プロジェクト構成
 
 ```
-app/                  # Expo Router pages
+app/                  # Expo Router ページ
 src/
-  core/               # Shared utilities (i18n, debug)
-  db/                 # SQLite database layer
-  features/           # Vertical feature slices
-  services/           # Business logic services
-  stores/             # Zustand state stores
-  types/              # TypeScript type definitions
-scripts/              # Development & build scripts
-plugins/              # Expo config plugins
-docs/                 # Documentation (Diataxis structure)
-__tests__/            # Unit tests
-maestro/              # E2E test flows
+  core/               # 共通ユーティリティ（i18n、デバッグ）
+  db/                 # SQLite データベース層
+  features/           # 機能ごとの垂直スライス
+  services/           # ビジネスロジックサービス
+  stores/             # Zustand ステートストア
+  types/              # TypeScript 型定義
+scripts/              # 開発・ビルドスクリプト
+plugins/              # Expo 設定プラグイン
+docs/                 # ドキュメント（Diataxis 構成）
+__tests__/            # ユニットテスト
+maestro/              # E2E テストフロー
 ```
 
-## Documentation
+## ドキュメント
 
-See `docs/README.md` for the full documentation map.
+ドキュメントの全体マップは `docs/README.md` を参照してください。
 
-## After Setup
+## セットアップ後にやること
 
-1. Fill in `.env` with your API keys (AdMob, RevenueCat, Sentry, EAS)
-2. Remove example code in `src/features/example/` and `src/db/`
-3. Update `docs/explanation/product_strategy.md` with your product vision
-4. Update `docs/reference/functional_spec.md` with your features
-5. Create your first ADR in `docs/adr/`
+1. `.env` に API キーを入力する（AdMob、RevenueCat、Sentry、EAS）
+2. `src/features/example/` と `src/db/` のサンプルコードを削除する
+3. `docs/explanation/product_strategy.md` にプロダクトのビジョンを書く
+4. `docs/reference/functional_spec.md` に機能仕様を書く
+5. `docs/adr/` に最初の ADR（Architecture Decision Record）を作成する

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@
 
 ### How-to（手順）
 
+- `docs/how-to/template-usage-guide.md`
+  - テンプレートの使い方完全ガイド（Phase 0〜4）
 - `docs/how-to/quickstart.md`
   - プロジェクトの初期セットアップ手順
 - `docs/how-to/whole_workflow.md`

--- a/docs/how-to/debug-guide.md
+++ b/docs/how-to/debug-guide.md
@@ -1,80 +1,80 @@
-# Debug Guide
+# デバッグガイド
 
-## Debug Session Management
+## デバッグセッションの管理
 
-The debug toolkit (`scripts/debug/`) provides structured debugging with automatic artifact collection.
+デバッグツールキット（`scripts/debug/`）を使うと、デバッグの手順を整理しながら、ログやスクリーンショットなどを自動で集めることができます。
 
-### Starting a Session
+### セッションを開始する
 
 ```bash
-pnpm debug:start           # With screen recording
-pnpm debug:start --no-record  # Without recording (faster)
+pnpm debug:start           # 画面録画あり
+pnpm debug:start --no-record  # 画面録画なし（より速い）
 ```
 
-This will:
+開始すると、以下の処理が自動で行われます:
 
-1. Verify device connection
-2. Clear logcat buffer
-3. Take a "before" screenshot
-4. Start logcat collection in background
-5. Start screen recording (optional)
+1. デバイスの接続を確認
+2. logcat のバッファをクリア
+3. 「操作前」のスクリーンショットを撮影
+4. バックグラウンドで logcat の収集を開始
+5. 画面録画を開始（オプション）
 
-### Stopping a Session
+### セッションを終了する
 
 ```bash
 pnpm debug:stop
 ```
 
-This collects all artifacts into `.debug-sessions/session_YYYYMMDD_HHMMSS/`:
+終了すると、すべてのデータが `.debug-sessions/session_YYYYMMDD_HHMMSS/` に保存されます:
 
-| Artifact        | Description                           |
-| --------------- | ------------------------------------- |
-| `before.png`    | Screenshot before operations          |
-| `after.png`     | Screenshot after operations           |
-| `logcat.log`    | Full log during session               |
-| `recording.mp4` | Screen recording                      |
-| `meminfo.txt`   | Memory usage snapshot                 |
-| `summary.md`    | Session summary with extracted errors |
+| ファイル名      | 説明                                 |
+| --------------- | ------------------------------------ |
+| `before.png`    | 操作前のスクリーンショット           |
+| `after.png`     | 操作後のスクリーンショット           |
+| `logcat.log`    | セッション中の全ログ                 |
+| `recording.mp4` | 画面録画                             |
+| `meminfo.txt`   | メモリ使用量のスナップショット       |
+| `summary.md`    | セッションのまとめ（エラー抽出つき） |
 
-### Checking Status
+### セッションの状態を確認する
 
 ```bash
 pnpm debug:status
 ```
 
-## Real-time Monitoring
+## リアルタイム監視
 
 ```bash
 pnpm monitor
 ```
 
-The monitor script tracks:
+監視スクリプトは以下を追跡します:
 
-- App process PID
-- Crashes and ANRs
-- Error-level log messages
-- Auto-saves crash logs
+- アプリプロセスの PID
+- クラッシュと ANR（Application Not Responding）
+- エラーレベルのログメッセージ
+- クラッシュログの自動保存
 
-## Common Debug Scenarios
+## よくあるデバッグの場面
 
-### App Crash
+### アプリがクラッシュしたとき
 
-1. Start a debug session: `pnpm debug:start`
-2. Reproduce the crash
-3. Stop the session: `pnpm debug:stop`
-4. Check `.debug-sessions/session_*/summary.md` for extracted errors
-5. Check `logcat.log` for full stack traces
+1. デバッグセッションを開始する: `pnpm debug:start`
+2. クラッシュを再現する
+3. セッションを終了する: `pnpm debug:stop`
+4. `.debug-sessions/session_*/summary.md` でエラー内容を確認する
+5. `logcat.log` でスタックトレース（Stack Trace）の詳細を確認する
 
-### Memory Issues
+### メモリの問題が疑われるとき
 
-1. Run the app for the suspected duration
-2. Stop the session to capture `meminfo.txt`
-3. Compare memory usage over time
+1. 問題が起きそうな時間だけアプリを動かす
+2. セッションを終了して `meminfo.txt` を取得する
+3. メモリ使用量の変化を比べる
 
-### WSL2 Specific
+### WSL2 を使っている場合
 
-If using WSL2 with a physical device:
+WSL2 で実機を使うときの注意点:
 
-- The scripts automatically handle `ADB_SERVER_SOCKET` issues
-- Use `env -u ADB_SERVER_SOCKET adb devices` to verify connection
-- Port forwarding is set up automatically by `dev-start.sh`
+- スクリプトは `ADB_SERVER_SOCKET` の問題を自動的に処理します
+- 接続の確認には `env -u ADB_SERVER_SOCKET adb devices` を使ってください
+- ポート転送は `dev-start.sh` によって自動的に設定されます

--- a/docs/how-to/quickstart.md
+++ b/docs/how-to/quickstart.md
@@ -1,104 +1,108 @@
-# Quick Start Guide
+# クイックスタートガイド
 
-## Prerequisites
+## 重要: Expo Go では動作しません
 
-- Node.js >= 22 (recommend using nvm)
-- pnpm (`npm install -g pnpm`)
-- Android Studio (for Android development)
-- Xcode (for iOS development, macOS only)
-- EAS CLI (`npm install -g eas-cli`)
+このテンプレートには AdMob、RevenueCat、SQLite などのネイティブモジュール（Native Module）が含まれているため、Expo Go では動作しません。アプリを実行するには、必ず開発ビルド（Dev Build）を作成してください。開発ビルドの作り方は「ビルド」セクションを参照してください。
 
-## Initial Setup
+## 必要なもの
+
+- Node.js 22 以上（nvm の利用をおすすめします）
+- pnpm（`npm install -g pnpm`）
+- Android Studio（Android 開発用）
+- Xcode（iOS 開発用、macOS のみ）
+- EAS CLI（`npm install -g eas-cli`）
+
+## 初期セットアップ
 
 ```bash
-# 1. Clone and enter the project
+# 1. リポジトリをクローンして移動
 git clone <your-repo-url>
 cd <your-project>
 
-# 2. Install dependencies
+# 2. 依存パッケージをインストール
 pnpm install
 
-# 3. Copy environment file
+# 3. 環境設定ファイルをコピー
 cp .env.example .env
-# Edit .env with your API keys
+# .env を開いて、API キーを入力してください
 
-# 4. Verify everything works
+# 4. すべて正しく動くか確認
 pnpm verify
 ```
 
-## Development Workflow
+## 開発の流れ
 
-### Android (Physical Device)
+### Android（実機）
 
 ```bash
-# One-command startup (checks ADB, sets up port forwarding, starts Metro)
+# ワンコマンドで起動（ADB 確認・ポート転送・Metro 起動をまとめて行います）
 pnpm dev:android
 
-# Or manually:
-adb devices                          # Verify device is connected
-adb reverse tcp:8081 tcp:8081       # Port forwarding
-pnpm dev                            # Start Metro
+# 手動で行う場合:
+adb devices                          # デバイスが接続されているか確認
+adb reverse tcp:8081 tcp:8081       # ポート転送
+pnpm dev                            # Metro を起動
 ```
 
-### Android (Emulator)
+### Android（エミュレータ）
 
 ```bash
 pnpm dev
-# Press 'a' in Metro to open on Android emulator
+# Metro で 'a' キーを押すと Android エミュレータで開きます
 ```
 
-### iOS (Simulator, macOS only)
+### iOS（シミュレータ、macOS のみ）
 
 ```bash
 pnpm dev
-# Press 'i' in Metro to open on iOS simulator
+# Metro で 'i' キーを押すと iOS シミュレータで開きます
 ```
 
-## Building
+## ビルド
 
-### Development Build (for dev-client)
+### 開発ビルド（Dev Build）（dev-client 用）
 
 ```bash
-# Local build
+# ローカルビルド
 eas build -p android --profile development --local
 
-# Cloud build
+# クラウドビルド
 eas build -p android --profile development
 ```
 
-### Preview Build (for testing)
+### プレビュービルド（Preview Build）（テスト用）
 
 ```bash
 eas build -p android --profile preview
 ```
 
-### Production Build
+### 本番ビルド（Production Build）
 
 ```bash
 eas build -p android --profile production
 ```
 
-## Debugging
+## デバッグ
 
 ```bash
-# Start a debug session (captures logs, screenshots, recordings)
+# デバッグセッションを開始（ログ・スクリーンショット・録画を記録します）
 pnpm debug:start
 
-# ... operate the app ...
+# ... アプリを操作する ...
 
-# Stop and collect artifacts
+# セッションを終了してデータを回収
 pnpm debug:stop
 
-# Real-time crash monitoring
+# リアルタイムのクラッシュ監視
 pnpm monitor
 ```
 
-## Testing
+## テスト
 
 ```bash
-# Unit tests
+# ユニットテスト
 pnpm test
 
-# E2E tests (requires built APK + emulator/device)
+# E2E テスト（ビルド済み APK + エミュレータまたは実機が必要です）
 pnpm test:e2e
 ```

--- a/docs/how-to/screenshot-generation.md
+++ b/docs/how-to/screenshot-generation.md
@@ -1,66 +1,66 @@
-# Store Screenshot Generation
+# ストアスクリーンショット生成
 
-## Overview
+## 概要
 
-The screenshot pipeline generates store-ready composite images for Apple App Store and Google Play from raw Maestro captures.
+スクリーンショットパイプライン（Screenshot Pipeline）は、Maestro で撮影した生のスクリーンショットから、Apple App Store と Google Play 向けの合成画像（Composite）を生成します。
 
-## Pipeline Phases
+## パイプラインの各フェーズ
 
-### Phase 0: Marketing Text Generation
+### Phase 0: マーケティングテキスト生成
 
-Use Claude Code to generate localized marketing copy:
+Claude Code を使って、各言語のマーケティング文言を作成します。
 
-1. Create `scripts/store-screenshots/screenshot-config.ts` from the template
-2. Ask Claude Code to generate `data/marketing-text.ts`
+1. テンプレートから `scripts/store-screenshots/screenshot-config.ts` を作成する
+2. Claude Code に `data/marketing-text.ts` の生成を依頼する
 
-### Phase 1: Raw Screenshot Capture
+### Phase 1: 生スクリーンショットの撮影
 
-Use Maestro to capture raw screenshots in each locale:
+Maestro を使って、各ロケール（言語設定）の生スクリーンショットを撮影します。
 
 ```bash
-# Run Maestro flows that capture screenshots
+# Maestro フローを実行してスクリーンショットを撮影する
 maestro test maestro/flows/screenshots.yml
 ```
 
-Screenshots are saved to `screenshots/raw/<locale_dir>/`.
+スクリーンショットは `screenshots/raw/<locale_dir>/` に保存されます。
 
-### Phase 2: Composite Generation
+### Phase 2: 合成画像の生成
 
 ```bash
-# All locales, both stores
+# 全ロケール・両ストア向けに生成
 npx tsx scripts/store-screenshots/generate.ts
 
-# Apple only
+# Apple のみ
 npx tsx scripts/store-screenshots/generate.ts --store apple
 
-# Specific locale
+# 特定のロケールのみ
 npx tsx scripts/store-screenshots/generate.ts --lang ja
 ```
 
-## Setup
+## セットアップ
 
 ```bash
-# 1. Install required tools
+# 1. 必要なツールをインストール
 pnpm add -D playwright sharp tsx
 npx playwright install chromium
 
-# 2. Create config from template
+# 2. テンプレートから設定ファイルを作成
 cp scripts/store-screenshots/screenshot-config.ts.template \
    scripts/store-screenshots/screenshot-config.ts
 
-# 3. Edit the config with your app's marketing text and screen definitions
+# 3. アプリのマーケティングテキストと画面定義を設定ファイルに記入する
 ```
 
-## Store Requirements
+## ストアの要件
 
-| Store           | Phone            | Tablet            |
+| ストア          | スマートフォン   | タブレット        |
 | --------------- | ---------------- | ----------------- |
 | Apple App Store | 1290x2796 (6.7") | 2048x2732 (12.9") |
 | Google Play     | 1290x2796        | 2048x2732         |
 
-## Tips
+## ヒント
 
-- Run Phase 1 on a real device for the most accurate screenshots
-- Keep marketing text short (2-3 words per line work best)
-- Test with one locale first before generating all 19
-- Screenshots are output to `screenshots/store/` (gitignored)
+- Phase 1 は実機で実行すると、もっとも正確なスクリーンショットが撮れます
+- マーケティングテキストは短めに（1 行あたり 2〜3 語がベスト）
+- 19 ロケール全部を生成する前に、まず 1 ロケールでテストしましょう
+- スクリーンショットは `screenshots/store/` に出力されます（gitignore 対象）

--- a/docs/how-to/sentry_setup.md
+++ b/docs/how-to/sentry_setup.md
@@ -1,32 +1,32 @@
-# Sentry Setup Guide
+# Sentry セットアップガイド
 
-## Overview
+## 概要
 
-[Sentry](https://sentry.io/) provides real-time crash reporting and error monitoring.
-Free tier: 5,000 errors/month (sufficient for early-stage apps).
+[Sentry](https://sentry.io/) は、リアルタイムでクラッシュレポートやエラー監視を行うサービスです。
+無料プランでは月 5,000 エラーまで対応でき、初期段階のアプリには十分です。
 
-## Prerequisites
+## 必要なもの
 
-- Sentry account + project created at https://sentry.io
-- Sentry DSN (found in Project Settings > Client Keys)
+- Sentry のアカウントと、https://sentry.io で作成したプロジェクト
+- Sentry DSN（Project Settings > Client Keys から確認できます）
 
-## Installation
+## インストール
 
 ```bash
 pnpm add @sentry/react-native
 ```
 
-## Configuration
+## 設定
 
-### 1. Add DSN to `.env`
+### 1. `.env` に DSN を追加する
 
 ```env
 SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 ```
 
-### 2. Add to `app.config.ts`
+### 2. `app.config.ts` に追加する
 
-In the `plugins` array:
+`plugins` 配列に以下を追加します:
 
 ```ts
 [
@@ -38,15 +38,15 @@ In the `plugins` array:
 ],
 ```
 
-In the `extra` section:
+`extra` セクションに以下を追加します:
 
 ```ts
 sentryDsn: process.env.SENTRY_DSN ?? '',
 ```
 
-### 3. Initialize in app entry
+### 3. アプリのエントリポイントで初期化する
 
-In `app/_layout.tsx`:
+`app/_layout.tsx` に以下を追加します:
 
 ```ts
 import * as Sentry from '@sentry/react-native';
@@ -58,9 +58,9 @@ Sentry.init({
 });
 ```
 
-### 4. EAS Build source maps
+### 4. EAS ビルドでソースマップ（Source Map）を設定する
 
-Add to `eas.json` build profiles:
+`eas.json` のビルドプロファイルに以下を追加します:
 
 ```json
 "production": {
@@ -70,15 +70,15 @@ Add to `eas.json` build profiles:
 }
 ```
 
-## Verification
+## 動作確認
 
-1. Build a preview APK
-2. Trigger an error (e.g., `throw new Error('Sentry test')`)
-3. Check Sentry dashboard for the error event
-4. Verify source maps are correctly symbolicated
+1. プレビュー APK をビルドする
+2. エラーを発生させる（例: `throw new Error('Sentry test')`）
+3. Sentry のダッシュボードでエラーイベントが表示されるか確認する
+4. ソースマップが正しく適用されているか確認する
 
-## Notes
+## 注意点
 
-- Sentry is disabled in `__DEV__` mode to avoid noise during development
-- For production, store `SENTRY_AUTH_TOKEN` as an EAS Secret, not in `.env`
-- Consider adding an Error Boundary component for graceful crash UI
+- 開発中のノイズを避けるため、`__DEV__` モードでは Sentry は無効になります
+- 本番環境では `SENTRY_AUTH_TOKEN` を `.env` ではなく EAS Secret として保存してください
+- クラッシュ時にわかりやすい画面を表示するために、エラーバウンダリ（Error Boundary）コンポーネントの追加を検討してください

--- a/docs/how-to/store-listing-guide.md
+++ b/docs/how-to/store-listing-guide.md
@@ -1,56 +1,56 @@
-# Store Listing Guide
+# ストア掲載ガイド
 
-## Overview
+## 概要
 
-Both Apple App Store and Google Play require localized store listings. This guide covers the process for creating and maintaining them.
+Apple App Store と Google Play では、どちらもローカライズ（多言語対応）されたストア掲載情報が必要です。このガイドでは、掲載情報の作成と管理の手順を説明します。
 
-## Store Listing Components
+## ストア掲載の構成要素
 
 ### Google Play
 
-| Field             | Max Length          | Notes                               |
-| ----------------- | ------------------- | ----------------------------------- |
-| Title             | 30 chars            | App name + key benefit              |
-| Short description | 80 chars            | One-line elevator pitch             |
-| Full description  | 4000 chars          | Features, benefits, differentiators |
-| Screenshots       | 2-8 per device type | Phone (required), Tablet (optional) |
-| Feature graphic   | 1024x500            | Promotional banner                  |
+| 項目                     | 最大文字数                 | 備考                                       |
+| ------------------------ | -------------------------- | ------------------------------------------ |
+| タイトル                 | 30 文字                    | アプリ名 + 主なメリット                    |
+| 短い説明                 | 80 文字                    | 一言でアプリを紹介する文                   |
+| 詳しい説明               | 4000 文字                  | 機能・メリット・他アプリとの違い           |
+| スクリーンショット       | デバイス種別ごとに 2〜8 枚 | スマートフォン（必須）、タブレット（任意） |
+| フィーチャーグラフィック | 1024x500                   | プロモーション用バナー画像                 |
 
 ### Apple App Store
 
-| Field            | Max Length          | Notes                         |
-| ---------------- | ------------------- | ----------------------------- |
-| App name         | 30 chars            | Same as Google Play title     |
-| Subtitle         | 30 chars            | Similar to short description  |
-| Description      | 4000 chars          | No HTML/markdown allowed      |
-| Promotional text | 170 chars           | Can be changed without review |
-| Screenshots      | Up to 10 per device | 6.7", 6.5", 5.5" required     |
+| 項目                   | 最大文字数               | 備考                          |
+| ---------------------- | ------------------------ | ----------------------------- |
+| アプリ名               | 30 文字                  | Google Play のタイトルと同じ  |
+| サブタイトル           | 30 文字                  | 短い説明と同じような内容      |
+| 説明                   | 4000 文字                | HTML やマークダウンは使えない |
+| プロモーションテキスト | 170 文字                 | 審査なしで変更できる          |
+| スクリーンショット     | デバイスごとに最大 10 枚 | 6.7"、6.5"、5.5" が必須       |
 
-## Workflow
+## ワークフロー
 
-### 1. Write English Copy First
+### 1. まず英語の文章を書く
 
-Start with the English (en-US) listing:
+英語（en-US）の掲載情報から始めます。
 
-- Write compelling, benefit-focused copy
-- Focus on what the user gets, not technical features
-- Use action verbs and clear language
+- ユーザーにとってのメリットが伝わる、魅力的な文章を書く
+- 技術的な機能よりも、ユーザーが得られる価値に焦点を当てる
+- 動作を表す動詞を使い、わかりやすい言葉で書く
 
-### 2. Generate Translations
+### 2. 翻訳を生成する
 
-Use Claude Code to translate to all 19 locales:
+Claude Code を使って 19 ロケールすべてに翻訳します。
 
-- Provide the English copy as source
-- Request translations that feel natural (not literal)
-- Review key markets (ja, de, fr, es) carefully
+- 英語の文章をソースとして渡す
+- 直訳ではなく、自然に読める翻訳をリクエストする
+- 主要市場（ja、de、fr、es）は特に注意してレビューする
 
-### 3. Generate Screenshots
+### 3. スクリーンショットを生成する
 
-Follow the [Screenshot Generation Guide](./screenshot-generation.md).
+[スクリーンショット生成ガイド](./screenshot-generation.md)に従ってください。
 
-### 4. Upload to Stores
+### 4. ストアにアップロードする
 
-Store listing files are organized in `docs/store-listing/`:
+ストア掲載ファイルは `docs/store-listing/` に整理されています。
 
 ```
 docs/store-listing/
@@ -66,11 +66,11 @@ docs/store-listing/
       ...
 ```
 
-## Localization Tips
+## ローカライズのコツ
 
-- Each market has different expectations for tone and style
-- Japanese: formal, feature-focused
-- German: precise, technical
-- Spanish: warm, benefit-focused
-- Don't translate app name unless there's a strong local brand reason
-- Test that translated text fits within character limits
+- 市場ごとにトーンやスタイルの期待値が異なります
+- 日本語: フォーマルで、機能を重視した表現
+- ドイツ語: 正確で、技術的な表現
+- スペイン語: 温かみがあり、メリットを重視した表現
+- アプリ名は、現地で強いブランド上の理由がない限り翻訳しないこと
+- 翻訳後のテキストが文字数制限内に収まっているかテストすること

--- a/docs/how-to/template-usage-guide.md
+++ b/docs/how-to/template-usage-guide.md
@@ -1,0 +1,310 @@
+# テンプレート使い方ガイド
+
+このドキュメントでは、App Factory テンプレートを使って新しいアプリを作るまでの手順を、Phase 0〜4 に分けて説明します。
+
+> **Phase 5 以降**（サービス連携、ストア公開、運用）は、各個別ドキュメントを参照してください。  
+> → [Phase 5 以降のリンク集](#phase-5-以降のリンク集)
+
+---
+
+## Phase 0: 前提条件（ツールの準備）
+
+アプリ開発を始める前に、以下のツールをパソコンにインストールしてください。
+
+### 必須ツール
+
+| ツール             | バージョン | 何をするもの？                            | インストール方法                                              |
+| ------------------ | ---------- | ----------------------------------------- | ------------------------------------------------------------- |
+| **Node.js**        | 22 以上    | JavaScript を動かすエンジン               | [nvm](https://github.com/nvm-sh/nvm) 経由がおすすめ           |
+| **pnpm**           | 10 以上    | ライブラリ（部品）を管理するツール        | `npm install -g pnpm`                                         |
+| **Git**            | 最新       | コードの変更履歴を管理するツール          | [git-scm.com](https://git-scm.com/)                           |
+| **Android Studio** | 最新       | Android アプリの開発環境                  | [developer.android.com](https://developer.android.com/studio) |
+| **JDK**            | 17         | Java の開発キット（Android ビルドに必要） | Android Studio に同梱                                         |
+| **EAS CLI**        | 16 以上    | Expo のビルド・配信ツール                 | `npm install -g eas-cli`                                      |
+
+### macOS の場合は追加で必要
+
+| ツール        | 何をするもの？       | インストール方法             |
+| ------------- | -------------------- | ---------------------------- |
+| **Xcode**     | iOS アプリの開発環境 | Mac App Store から           |
+| **CocoaPods** | iOS のライブラリ管理 | `sudo gem install cocoapods` |
+
+### nvm で Node.js 22 をインストールする方法
+
+```bash
+# nvm をインストール（まだの場合）
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+
+# ターミナルを再起動してから:
+nvm install 22
+nvm use 22
+
+# 確認
+node --version  # v22.x.x と表示されればOK
+```
+
+### pnpm と EAS CLI のインストール
+
+```bash
+npm install -g pnpm
+npm install -g eas-cli
+
+# 確認
+pnpm --version   # 10.x.x
+eas --version     # eas-cli/16.x.x
+```
+
+---
+
+## Phase 1: リポジトリ作成
+
+### GitHub の「Use this template」を使う
+
+1. ブラウザで [テンプレートリポジトリ](https://github.com/doooooraku/app_template) を開く
+2. 緑の **「Use this template」** ボタンをクリック
+3. **「Create a new repository」** を選ぶ
+4. リポジトリ名を入力（例: `my-awesome-app`）
+5. **Private** を選んで **「Create repository」** をクリック
+
+> **「Fork」との違い:**
+>
+> - **Use this template**: テンプレートのコミット履歴を引き継がず、まっさらな状態で始められる（おすすめ）
+> - **Fork**: テンプレートの全履歴を引き継ぐ。テンプレート自体を改善したい場合に使う
+
+### ローカルにクローン
+
+```bash
+git clone https://github.com/あなたのユーザー名/リポジトリ名.git
+cd リポジトリ名
+```
+
+---
+
+## Phase 2: 初期セットアップ（setup.sh）
+
+### setup.sh を実行する
+
+```bash
+bash setup.sh
+```
+
+スクリプトが以下の項目を聞いてきます。一つずつ入力してください。
+
+### 入力項目の説明
+
+| 項目                       | 意味                               | 入力例                       | 補足                     |
+| -------------------------- | ---------------------------------- | ---------------------------- | ------------------------ |
+| **アプリ表示名**           | ユーザーに見えるアプリの名前       | `My App`                     | スペースや日本語もOK     |
+| **アプリスラッグ**         | URL やフォルダ名に使う英数字の名前 | `my-app`                     | 小文字・ハイフンのみ推奨 |
+| **Android パッケージ名**   | Android 上でアプリを識別する名前   | `com.example.myapp`          | 一度公開したら変更不可   |
+| **iOS バンドルID**         | iOS 上でアプリを識別する名前       | `com.example.myapp`          | 通常 Android と同じ      |
+| **ディープリンクスキーム** | アプリを URL から開くための接頭辞  | `myapp`                      | 小文字英数字のみ         |
+| **アプリの一行説明**       | アプリの簡単な説明                 | `毎日の習慣を記録するアプリ` |                          |
+| **EAS プロジェクトID**     | EAS のプロジェクト識別子           | `xxxxxxxx-xxxx-...`          | 不明なら空欄でOK         |
+
+### EAS プロジェクト ID の取得方法
+
+EAS プロジェクト ID は、Expo のクラウドビルドやOTAアップデートに必要です。後から設定もできます。
+
+1. [expo.dev](https://expo.dev/) にログインする
+2. **「Projects」** →**「Create a project」** をクリック
+3. プロジェクト名を入力して作成
+4. プロジェクトページの URL に含まれる UUID がプロジェクト ID
+   - 例: `https://expo.dev/accounts/xxx/projects/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+   - この `xxxxxxxx-xxxx-...` の部分がプロジェクト ID
+
+> **💡 後から設定する場合:** `.env` ファイルの `EAS_PROJECT_ID=` に値を入れればOK
+
+### setup.sh が内部でやっていること
+
+1. コードベース内の `{{APP_NAME}}` などのプレースホルダーをあなたの入力値に置換
+2. `.env.example` を元に `.env` ファイルを作成
+3. `app.json` と `package.json` を更新
+4. `TEMPLATE_README.md` を削除（セットアップ後は不要）
+5. `pnpm install` で依存関係をインストール
+6. `pnpm verify` で全チェックを実行
+
+### よくある間違い
+
+| 間違い                       | 対処                                                    |
+| ---------------------------- | ------------------------------------------------------- |
+| パッケージ名に大文字を使った | 小文字のみ使用する（例: `com.Example` → `com.example`） |
+| スラッグにスペースを入れた   | ハイフンに置き換える（例: `my app` → `my-app`）         |
+| EAS ID を間違えた            | `.env` の `EAS_PROJECT_ID` を直接修正すればOK           |
+
+---
+
+## Phase 3: 初回起動
+
+### 重要: Expo Go では動きません
+
+このテンプレートには **ネイティブモジュール**（AdMob、RevenueCat、SQLite など）が含まれているため、Expo Go アプリでは実行できません。**Dev Build**（開発用ビルド）を作成する必要があります。
+
+> **Expo Go とは?**
+> Expo が提供する汎用アプリ。簡単なアプリならこれで動くが、ネイティブモジュールを使うアプリには対応していない。
+>
+> **Dev Build とは?**
+> あなたのアプリ専用の開発用バイナリ。ネイティブモジュールを含んでビルドされるため、すべての機能が動く。
+
+### Dev Build の作り方（Android）
+
+```bash
+# ローカルでビルド（おすすめ・無料）
+eas build -p android --profile development --local
+
+# または EAS クラウドでビルド（月30回まで無料）
+eas build -p android --profile development
+```
+
+ビルドが完了すると `.apk` ファイルが生成されます。
+
+### APK をデバイスにインストール
+
+```bash
+# USB で接続したデバイスにインストール
+adb install dist/app-factory-template-dev.apk
+
+# デバイスが認識されているか確認
+adb devices
+```
+
+### 開発サーバーを起動
+
+```bash
+pnpm dev
+```
+
+デバイスでアプリを開くと、Metro（開発サーバー）に自動接続されます。コードを変更すると画面が即座に更新されます（Hot Reload）。
+
+### 物理デバイスでの起動（ワンコマンド）
+
+```bash
+# ADB接続確認 + ポートフォワーディング + Metro起動を一括で行う
+pnpm dev:android
+```
+
+### Dev Build の作り方（iOS・macOS のみ）
+
+```bash
+# ローカルでビルド
+eas build -p ios --profile development --local
+
+# シミュレータで起動
+pnpm dev
+# Metro で 'i' キーを押す
+```
+
+---
+
+## Phase 4: カスタマイズ
+
+### 削除すべきサンプルコード
+
+テンプレートにはサンプルコードが含まれています。自分のアプリを作り始める前に、以下を削除・置き換えてください。
+
+| ファイル・フォルダ                    | 内容                   | 対処                     |
+| ------------------------------------- | ---------------------- | ------------------------ |
+| `src/features/example/`               | サンプル機能           | フォルダごと削除         |
+| `src/db/exampleRepository.ts`         | サンプル DB リポジトリ | 削除                     |
+| `src/db/schema.ts`                    | サンプルテーブル定義   | 自分のスキーマに書き換え |
+| `app/(tabs)/explore.tsx`              | サンプル画面           | 自分の画面に書き換え     |
+| `components/hello-wave.tsx`           | サンプルコンポーネント | 削除                     |
+| `components/parallax-scroll-view.tsx` | サンプルコンポーネント | 必要なければ削除         |
+
+### 画面の追加方法
+
+Expo Router はファイルベースのルーティングを使います。ファイルを置くだけで画面が追加されます。
+
+```bash
+# 例: 新しいタブ画面を追加
+app/(tabs)/my-screen.tsx    # ← このファイルを作ると /my-screen ルートが追加される
+```
+
+```tsx
+// app/(tabs)/my-screen.tsx の最小構成
+import { View, Text } from 'react-native';
+
+export default function MyScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Hello!</Text>
+    </View>
+  );
+}
+```
+
+### i18n キーの追加方法
+
+1. `src/core/i18n/locales/en.ts` にキーを追加
+2. **全19言語のファイル** に同じキーを追加（`...baseEn` フォールバックに頼らない）
+3. `pnpm i18n:check` で漏れがないか確認
+
+```ts
+// src/core/i18n/locales/en.ts
+export const en = {
+  // ... 既存のキー
+  myFeature: {
+    title: 'My Feature',
+    description: 'This is my feature',
+  },
+};
+```
+
+> **重要:** `...baseEn` スプレッドがあると英語がフォールバックとして使われますが、これに頼ると「翻訳されていない」キーを見落とします。必ず全ファイルに明示的に追加してください。
+
+### DB テーブルの追加方法
+
+このテンプレートでは `expo-sqlite` と `PRAGMA user_version` によるマイグレーションパターンを使います。
+
+1. `src/db/schema.ts` にテーブル定義を追加
+2. `src/db/db.ts` のマイグレーション関数に `CREATE TABLE` を追加
+3. `PRAGMA user_version` をインクリメント
+
+```ts
+// マイグレーションの例
+if (currentVersion < 2) {
+  db.execSync(`
+    CREATE TABLE IF NOT EXISTS my_table (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+db.execSync('PRAGMA user_version = 2');
+```
+
+> **注意:** `ALTER TABLE ADD COLUMN` を使う場合は、カラムの存在チェックを先に行ってください（冪等性の確保）。詳しくは [lessons.md](../reference/tasks/lessons.md) を参照。
+
+### アイコン・スプラッシュの差し替え
+
+| ファイル                                    | 用途                       | サイズ        |
+| ------------------------------------------- | -------------------------- | ------------- |
+| `assets/images/icon.png`                    | アプリアイコン             | 1024x1024     |
+| `assets/images/splash-icon.png`             | 起動画面のロゴ             | 200x200 以上  |
+| `assets/images/android-icon-foreground.png` | Android Adaptive Icon 前景 | 108dp (432px) |
+| `assets/images/android-icon-background.png` | Android Adaptive Icon 背景 | 108dp (432px) |
+| `assets/images/android-icon-monochrome.png` | Android モノクロアイコン   | 108dp (432px) |
+| `assets/images/favicon.png`                 | Web 用ファビコン           | 48x48         |
+
+> `app.json` の `icon`、`splash`、`android.adaptiveIcon` のパスがこれらのファイルを参照しています。ファイル名を変える場合は `app.json` も更新してください。
+
+---
+
+## Phase 5 以降のリンク集
+
+セットアップとカスタマイズが終わったら、以下のドキュメントを参照してください。
+
+| Phase | 内容                              | ドキュメント                                           |
+| ----- | --------------------------------- | ------------------------------------------------------ |
+| 5     | サービス連携（Sentry）            | [sentry_setup.md](./sentry_setup.md)                   |
+| 5     | サービス連携（AdMob・RevenueCat） | `.env` のキー設定で有効化                              |
+| 6     | テスト                            | [testing.md](./testing.md)                             |
+| 6     | デバッグ                          | [debug-guide.md](./debug-guide.md)                     |
+| 7     | ストア掲載準備                    | [store-listing-guide.md](./store-listing-guide.md)     |
+| 7     | スクリーンショット生成            | [screenshot-generation.md](./screenshot-generation.md) |
+| 8     | Android ビルド                    | [android\_ビルド手順.md](./android_ビルド手順.md)      |
+| 8     | iOS ビルド                        | [ios\_ビルド手順.md](./ios_ビルド手順.md)              |
+| 9     | 開発フロー全体                    | [whole_workflow.md](./whole_workflow.md)               |
+| 9     | Git ワークフロー                  | [git_workflow.md](./git_workflow.md)                   |
+| 9     | 実装ルール                        | [実装ルール.md](./実装ルール.md)                       |

--- a/docs/reference/feature_spec_template.md
+++ b/docs/reference/feature_spec_template.md
@@ -1,88 +1,88 @@
-# Feature Spec: [Feature Name]
+# 機能仕様書（Feature Spec）: [機能名]
 
 > Issue: #xxx
 > Date: YYYY-MM-DD
 > Status: Draft / Approved / Implemented
 
-## Goal (Why)
+## 目的（なぜこの機能が必要か）
 
-<!-- 1-2 sentences: why this feature exists, what user value it delivers -->
+<!-- 1-2文で、この機能が存在する理由と、ユーザーにどんな価値を届けるかを書く -->
 
-## Acceptance Criteria
+## 受け入れ条件（Acceptance Criteria）
 
 - [ ] AC-1:
 - [ ] AC-2:
 - [ ] AC-3:
 
-## Scope
+## スコープ
 
-### In Scope
-
--
-
-### Out of Scope (Non-goals)
+### 対象範囲
 
 -
 
-## Design
+### 対象外（Non-goals）
 
-### Affected Files
+-
 
-| File      | Change |
-| --------- | ------ |
-| `src/...` |        |
-| `app/...` |        |
+## 設計
 
-### State Changes
+### 影響するファイル
 
-<!-- Zustand store / React Query cache changes -->
+| ファイル  | 変更内容 |
+| --------- | -------- |
+| `src/...` |          |
+| `app/...` |          |
 
-## Impact Checklist
+### 状態の変更
 
-### DB Schema
+<!-- Zustand ストア / React Query キャッシュの変更点 -->
 
-- [ ] No DB changes
-- [ ] New table / column added
-  - [ ] Migration is idempotent (column existence check before ALTER TABLE)
-  - [ ] `PRAGMA user_version` is unconditionally set after migration
-  - [ ] Backup types (`BackupXxx`) updated with new field (as optional `?`)
-  - [ ] Export mapping in backupService updated
-  - [ ] Import INSERT statement in backupService updated
+## 影響チェックリスト
 
-### i18n
+### DB スキーマ
 
-- [ ] No new translation keys
-- [ ] New keys added to `en.ts`
-  - [ ] All 18 locale files explicitly override new keys (do NOT rely on `...baseEn` fallback)
-  - [ ] `pnpm i18n:check` passes
+- [ ] DB の変更なし
+- [ ] 新しいテーブル / カラムを追加
+  - [ ] マイグレーションが冪等（べきとう）である（ALTER TABLE の前にカラムの存在をチェックする）
+  - [ ] `PRAGMA user_version` がマイグレーション後に無条件でセットされる
+  - [ ] バックアップ型（`BackupXxx`）に新しいフィールドを追加済み（オプショナル `?` として）
+  - [ ] backupService のエクスポートマッピングを更新済み
+  - [ ] backupService のインポート INSERT 文を更新済み
 
-### Documents
+### i18n（多言語対応）
 
-- [ ] No doc changes needed
-- [ ] Updated files:
-  - [ ] `constraints.md` (if rules/limits changed)
-  - [ ] `functional_spec.md` (if behavior changed)
-  - [ ] `glossary.md` (if new terms introduced)
-  - [ ] ADR created (if architectural decision made)
+- [ ] 新しい翻訳キーなし
+- [ ] `en.ts` に新しいキーを追加
+  - [ ] 18 個すべてのロケールファイルで新しいキーを明示的にオーバーライド済み（`...baseEn` のフォールバックに頼らないこと）
+  - [ ] `pnpm i18n:check` が通る
 
-### User-Facing Text
+### ドキュメント
 
-- [ ] No technical jargon in user-visible strings (no filenames, JSON, schema references)
+- [ ] ドキュメントの変更なし
+- [ ] 更新したファイル:
+  - [ ] `constraints.md`（ルールや制限が変わった場合）
+  - [ ] `functional_spec.md`（動作が変わった場合）
+  - [ ] `glossary.md`（新しい用語が出てきた場合）
+  - [ ] ADR を作成（アーキテクチャに関する決定をした場合）
 
-## Test Plan
+### ユーザー向けテキスト
 
-### Unit Tests
+- [ ] ユーザーに見える文字列に専門用語を含めない（ファイル名、JSON、スキーマの参照などを使わない）
 
-- [ ]
+## テスト計画
 
-### E2E (Maestro)
-
-- [ ]
-
-### Manual Verification
+### ユニットテスト
 
 - [ ]
 
-## Risks
+### E2E テスト（Maestro）
 
-<!-- What could go wrong? What's the rollback plan? -->
+- [ ]
+
+### 手動確認
+
+- [ ]
+
+## リスク
+
+<!-- 何がうまくいかない可能性があるか？ロールバック（元に戻す）計画は？ -->

--- a/docs/reference/tasks/lessons.md
+++ b/docs/reference/tasks/lessons.md
@@ -1,65 +1,65 @@
-# Lessons Learned
+# 学んだこと（Lessons Learned）
 
-Record patterns and corrections here so the same mistakes are not repeated.
+同じミスを繰り返さないように、パターンや修正内容をここに記録する。
 
-## Format
+## フォーマット
 
 ```
-### [Date] Category: Short title
-- What happened:
-- Root cause:
-- Rule: (what to do differently next time)
+### [日付] カテゴリ: 短いタイトル
+- 何が起きたか:
+- 根本原因:
+- ルール: (次回どうすべきか)
 ```
 
 ---
 
-## Seed Lessons (from prior projects)
+## 初期レッスン（過去のプロジェクトから）
 
-### Document Management
+### ドキュメント管理
 
-#### Doc map update on new file
+#### 新しいファイルを追加したらドキュメントマップを更新する
 
-- **Rule:** When adding a new document, always update the docs/README.md file map.
-- **Root cause:** No checklist for "other files affected" when creating docs.
+- **ルール:** 新しいドキュメントを追加したら、必ず docs/README.md のファイルマップを更新する。
+- **根本原因:** ドキュメント作成時に「他に影響するファイル」を確認するチェックリストがなかった。
 
-#### Feature inventory before replacement
+#### 機能を置き換える前に既存機能を一覧にする
 
-- **Rule:** When replacing an existing feature with a new version, inventory all capabilities of the old version first. Distinguish intentional removals from oversights.
-- **Root cause:** Old feature's capabilities were not documented externally, so they were missed during redesign.
+- **ルール:** 既存の機能を新しいバージョンに置き換えるときは、まず古いバージョンの全機能を一覧にする。意図的に削除したものと見落としを区別する。
+- **根本原因:** 古い機能の能力が外部にドキュメント化されていなかったため、再設計時に見落とされた。
 
-#### Legacy reference update
+#### 古い参照の更新
 
-- **Rule:** Definition of Done must include "cross-reference check for related documents."
-- **Root cause:** New feature TODO did not include checking existing docs for stale references.
-
----
-
-### DB / Data
-
-#### Migration idempotency
-
-- **Rule:** `PRAGMA user_version` must be set unconditionally (not inside an if-block). `ALTER TABLE ADD COLUMN` must check column existence first.
-- **Root cause:** `CREATE TABLE IF NOT EXISTS` is idempotent, but `ALTER TABLE ADD COLUMN` is not. On app restart, version=0 triggers re-migration and "duplicate column" error.
-
-#### Backup/export field coverage
-
-- **Rule:** When adding a column to `reports` or `photos`, always update the corresponding Backup type, export mapping, and import INSERT in backupService.
-- **Root cause:** No process to check backup impact when schema changes.
+- **ルール:** 完了の定義（Definition of Done）に「関連ドキュメントのクロスリファレンスチェック」を含める。
+- **根本原因:** 新機能の TODO に、既存ドキュメントの古い参照を確認する項目がなかった。
 
 ---
 
-### i18n
+### DB / データ
 
-#### Don't rely on baseEn fallback
+#### マイグレーションの冪等性（べきとうせい）
 
-- **Rule:** New translation keys must be explicitly overridden in all locale files. `...baseEn` spread makes keys "exist" but they remain untranslated.
-- **Root cause:** The i18n:check script validates en.ts keys vs code usage, but doesn't detect locale files that silently inherit English via spread.
+- **ルール:** `PRAGMA user_version` は無条件でセットする（if ブロックの中に入れない）。`ALTER TABLE ADD COLUMN` はカラムの存在を先にチェックする。
+- **根本原因:** `CREATE TABLE IF NOT EXISTS` は冪等だが、`ALTER TABLE ADD COLUMN` は冪等ではない。アプリ再起動時に version=0 となり、再マイグレーションが走って「カラムが重複しています」エラーになる。
+
+#### バックアップ / エクスポートのフィールドカバレッジ
+
+- **ルール:** `reports` や `photos` にカラムを追加したら、必ず対応する Backup 型、エクスポートマッピング、backupService のインポート INSERT を更新する。
+- **根本原因:** スキーマ変更時にバックアップへの影響を確認するプロセスがなかった。
 
 ---
 
-### UX / Copy
+### i18n（多言語対応）
 
-#### No technical jargon in user-facing text
+#### baseEn のフォールバックに頼らない
 
-- **Rule:** Never show filenames, directory names, JSON, schema, or other internal terms to users. Describe what something does, not what it is technically.
-- **Root cause:** Developer described backup contents accurately (`manifest.json + photos/`) instead of describing their purpose.
+- **ルール:** 新しい翻訳キーは、すべてのロケールファイルで明示的にオーバーライドする。`...baseEn` のスプレッドを使うとキーは「存在する」が、翻訳されないまま英語が残る。
+- **根本原因:** i18n:check スクリプトは en.ts のキーとコードの使用箇所を照合するが、スプレッドで英語をそのまま引き継いでいるロケールファイルは検出できない。
+
+---
+
+### UX / 文言
+
+#### ユーザー向けテキストに専門用語を使わない
+
+- **ルール:** ファイル名、ディレクトリ名、JSON、スキーマなどの内部用語をユーザーに見せない。技術的に「何であるか」ではなく、「何をするか」を説明する。
+- **根本原因:** 開発者がバックアップの中身を正確に記述した（`manifest.json + photos/`）が、その目的を説明すべきだった。

--- a/docs/store-listing/README.md
+++ b/docs/store-listing/README.md
@@ -1,45 +1,45 @@
-# Store Listing Assets
+# ストア掲載アセット
 
-Localized store listing content for Apple App Store and Google Play.
+Apple App Store と Google Play 向けの、ローカライズされたストア掲載コンテンツです。
 
-## Structure
+## ディレクトリ構成
 
 ```
 store-listing/
   android/
     <locale>/
-      title.txt              # App title (max 30 chars)
-      short-description.txt  # Short description (max 80 chars)
-      full-description.txt   # Full description (max 4000 chars)
+      title.txt              # アプリタイトル（最大 30 文字）
+      short-description.txt  # 短い説明（最大 80 文字）
+      full-description.txt   # 詳しい説明（最大 4000 文字）
   ios/
     <locale>/
-      description.txt        # App Store description
+      description.txt        # App Store の説明
 ```
 
-## Supported Locales (19)
+## 対応ロケール（19 言語）
 
-| Code   | Language              | Android Dir | iOS Dir |
-| ------ | --------------------- | ----------- | ------- |
-| en     | English               | en-US       | en-US   |
-| ja     | Japanese              | ja-JP       | ja      |
-| fr     | French                | fr-FR       | fr-FR   |
-| es     | Spanish               | es-ES       | es-ES   |
-| de     | German                | de-DE       | de-DE   |
-| it     | Italian               | it-IT       | it      |
-| pt     | Portuguese            | pt-BR       | pt-BR   |
-| ru     | Russian               | ru-RU       | ru      |
-| zhHans | Chinese (Simplified)  | zh-Hans     | zh-Hans |
-| zhHant | Chinese (Traditional) | zh-Hant     | zh-Hant |
-| ko     | Korean                | ko-KR       | ko      |
-| hi     | Hindi                 | hi-IN       | hi      |
-| id     | Indonesian            | id          | id      |
-| th     | Thai                  | th          | th      |
-| vi     | Vietnamese            | vi          | vi      |
-| tr     | Turkish               | tr-TR       | tr      |
-| nl     | Dutch                 | nl-NL       | nl      |
-| pl     | Polish                | pl-PL       | pl      |
-| sv     | Swedish               | sv-SE       | sv      |
+| コード | 言語             | Android ディレクトリ | iOS ディレクトリ |
+| ------ | ---------------- | -------------------- | ---------------- |
+| en     | 英語             | en-US                | en-US            |
+| ja     | 日本語           | ja-JP                | ja               |
+| fr     | フランス語       | fr-FR                | fr-FR            |
+| es     | スペイン語       | es-ES                | es-ES            |
+| de     | ドイツ語         | de-DE                | de-DE            |
+| it     | イタリア語       | it-IT                | it               |
+| pt     | ポルトガル語     | pt-BR                | pt-BR            |
+| ru     | ロシア語         | ru-RU                | ru               |
+| zhHans | 中国語（簡体字） | zh-Hans              | zh-Hans          |
+| zhHant | 中国語（繁体字） | zh-Hant              | zh-Hant          |
+| ko     | 韓国語           | ko-KR                | ko               |
+| hi     | ヒンディー語     | hi-IN                | hi               |
+| id     | インドネシア語   | id                   | id               |
+| th     | タイ語           | th                   | th               |
+| vi     | ベトナム語       | vi                   | vi               |
+| tr     | トルコ語         | tr-TR                | tr               |
+| nl     | オランダ語       | nl-NL                | nl               |
+| pl     | ポーランド語     | pl-PL                | pl               |
+| sv     | スウェーデン語   | sv-SE                | sv               |
 
-## Workflow
+## ワークフロー
 
-See [Store Listing Guide](../how-to/store-listing-guide.md) for the full process.
+詳しい手順は[ストア掲載ガイド](../how-to/store-listing-guide.md)を参照してください。

--- a/scripts/store-screenshots/README.md
+++ b/scripts/store-screenshots/README.md
@@ -1,61 +1,61 @@
-# Store Screenshot Pipeline
+# ストアスクリーンショットパイプライン（Store Screenshot Pipeline）
 
-Generates store-ready composite screenshots for Apple App Store and Google Play.
+Apple App Store と Google Play 向けの、ストア掲載用の合成スクリーンショットを生成する。
 
-Each composite image consists of a white background, a marketing text caption at the top, and the app screenshot with rounded corners and a subtle shadow below.
+それぞれの合成画像は、白い背景の上にマーケティングテキストのキャプション、その下に角丸と薄い影のついたアプリのスクリーンショットで構成される。
 
-## Pipeline Overview
+## パイプラインの概要
 
-### Phase 0 -- Marketing Text Generation
+### Phase 0 -- マーケティングテキストの生成
 
-Claude Code reads `screenshot-config.ts` and generates `data/marketing-text.ts` containing localized marketing copy for each screen and locale.
+Claude Code が `screenshot-config.ts` を読み込み、各画面・各ロケールのマーケティング文言を含む `data/marketing-text.ts` を生成する。
 
-**Input:** `screenshot-config.ts` (app info, persona, screen definitions, text guidelines)
-**Output:** `data/marketing-text.ts`
+**入力:** `screenshot-config.ts`（アプリ情報、ペルソナ、画面の定義、テキストのガイドライン）
+**出力:** `data/marketing-text.ts`
 
-### Phase 1 -- Raw Screenshot Capture
+### Phase 1 -- 生スクリーンショットの撮影
 
-Maestro captures raw screenshots from the running app for each locale. Screenshots are saved to `screenshots/raw/<locale_dir>/`.
+Maestro が動作中のアプリから各ロケールの生スクリーンショットを撮影する。スクリーンショットは `screenshots/raw/<locale_dir>/` に保存される。
 
-**Input:** Maestro flow files
-**Output:** `screenshots/raw/<locale_dir>/<screen_id>.png`
+**入力:** Maestro フローファイル
+**出力:** `screenshots/raw/<locale_dir>/<screen_id>.png`
 
-### Phase 2 -- Composite Generation
+### Phase 2 -- 合成画像の生成
 
-The `generate.ts` script composes the final store images:
+`generate.ts` スクリプトが最終的なストア画像を合成する:
 
-1. **Compose** -- Builds an HTML page with marketing text + cropped screenshot
-2. **Render** -- Playwright renders the HTML at the exact store dimensions
-3. **Postprocess** -- Sharp flattens alpha, embeds sRGB ICC, and verifies dimensions
+1. **合成（Compose）** -- マーケティングテキストとトリミングしたスクリーンショットを含む HTML ページを作成する
+2. **レンダリング（Render）** -- Playwright がストアの正確なサイズで HTML をレンダリングする
+3. **後処理（Postprocess）** -- Sharp がアルファを平坦化し、sRGB ICC を埋め込み、サイズを検証する
 
-**Input:** Raw screenshots + marketing text
-**Output:** `screenshots/store/<store>/<locale_dir>/<screen_id>.png`
+**入力:** 生スクリーンショット + マーケティングテキスト
+**出力:** `screenshots/store/<store>/<locale_dir>/<screen_id>.png`
 
-## Setup
+## セットアップ
 
-### 1. Install dependencies
+### 1. 依存パッケージのインストール
 
 ```bash
 pnpm add -D playwright sharp tsx
 npx playwright install chromium
 ```
 
-### 2. Create screenshot-config.ts
+### 2. screenshot-config.ts の作成
 
 ```bash
 cp scripts/store-screenshots/screenshot-config.ts.template \
    scripts/store-screenshots/screenshot-config.ts
 ```
 
-Edit the file and fill in all TODO sections with your app-specific values.
+ファイルを編集して、すべての TODO セクションにアプリ固有の値を入力する。
 
-### 3. Generate marketing text (Phase 0)
+### 3. マーケティングテキストの生成（Phase 0）
 
-Ask Claude Code to read `screenshot-config.ts` and generate `data/marketing-text.ts`.
+Claude Code に `screenshot-config.ts` を読み込ませて `data/marketing-text.ts` を生成させる。
 
-### 4. Add pnpm script
+### 4. pnpm スクリプトの追加
 
-Add to `package.json`:
+`package.json` に以下を追加する:
 
 ```json
 {
@@ -65,52 +65,52 @@ Add to `package.json`:
 }
 ```
 
-## Usage
+## 使い方
 
 ```bash
-# Generate for all locales, both stores
+# 全ロケール・両ストア向けに生成
 pnpm store-screenshots
 
-# Apple App Store only
+# Apple App Store のみ
 pnpm store-screenshots --store apple
 
-# Google Play, Japanese only
+# Google Play、日本語のみ
 pnpm store-screenshots --store google --lang ja
 
-# Multiple locales
+# 複数ロケール
 pnpm store-screenshots --lang en,ja,fr
 ```
 
-## Output Sizes
+## 出力サイズ
 
-| Store  | Dimensions  | Notes                                    |
-| ------ | ----------- | ---------------------------------------- |
-| Apple  | 1320 x 2868 | iPhone 6.9" -- mandatory for App Store   |
-| Google | 1080 x 1920 | Phone -- standard for Google Play (9:16) |
+| ストア | サイズ      | 備考                                      |
+| ------ | ----------- | ----------------------------------------- |
+| Apple  | 1320 x 2868 | iPhone 6.9" -- App Store で必須           |
+| Google | 1080 x 1920 | スマートフォン -- Google Play 標準 (9:16) |
 
-## Directory Structure
+## ディレクトリ構成
 
 ```
 scripts/store-screenshots/
-  generate.ts                    # CLI entry point
-  screenshot-config.ts           # App-specific config (create from .template)
-  screenshot-config.ts.template  # Template with TODOs
+  generate.ts                    # CLI エントリーポイント
+  screenshot-config.ts           # アプリ固有の設定（.template から作成）
+  screenshot-config.ts.template  # TODO 付きのテンプレート
   data/
-    marketing-text.ts            # Generated marketing copy
+    marketing-text.ts            # 生成されたマーケティング文言
   lib/
-    config.ts                    # Size constants and path resolution
-    fonts.ts                     # Font management (@font-face generation)
-    renderer.ts                  # Playwright rendering
-    template.ts                  # HTML template generation
-    postprocess.ts               # Sharp crop/flatten/verify
+    config.ts                    # サイズ定数とパス解決
+    fonts.ts                     # フォント管理（@font-face の生成）
+    renderer.ts                  # Playwright レンダリング
+    template.ts                  # HTML テンプレート生成
+    postprocess.ts               # Sharp によるトリミング / 平坦化 / 検証
 
 screenshots/
-  raw/<locale_dir>/              # Maestro captures (Phase 1 input)
-  store/<store>/<locale_dir>/    # Final composites (Phase 2 output)
+  raw/<locale_dir>/              # Maestro の撮影結果（Phase 1 の入力）
+  store/<store>/<locale_dir>/    # 最終合成画像（Phase 2 の出力）
 ```
 
-## Fonts
+## フォント
 
-By default, the pipeline uses Noto Sans variable fonts from `assets/fonts/`. The font module (`lib/fonts.ts`) automatically selects the correct font for each locale (e.g. Noto Sans JP for Japanese, Noto Sans SC for Simplified Chinese).
+デフォルトでは、パイプラインは `assets/fonts/` にある Noto Sans 可変フォントを使用する。フォントモジュール（`lib/fonts.ts`）が各ロケールに合ったフォントを自動的に選択する（例: 日本語には Noto Sans JP、簡体字中国語には Noto Sans SC）。
 
-If your app uses different fonts, edit the `FONTS` map in `lib/fonts.ts`.
+アプリで別のフォントを使う場合は、`lib/fonts.ts` の `FONTS` マップを編集する。


### PR DESCRIPTION
## Summary

- `docs/how-to/template-usage-guide.md` を新規作成（Phase 0〜4 テンプレート使い方完全ガイド）
- 英語ドキュメント12ファイルを日本語に翻訳
- `docs/README.md` のインデックスに `template-usage-guide.md` を追加
- `quickstart.md` に Expo Go 非対応の警告を追記

## 変更ファイル（13ファイル）

### 新規作成
| ファイル | 内容 |
|---------|------|
| `docs/how-to/template-usage-guide.md` | Phase 0〜4 完全ガイド（前提条件、リポジトリ作成、setup.sh、初回起動、カスタマイズ） |

### 日本語化
| ファイル | 内容 |
|---------|------|
| `README.md` | リポジトリトップ |
| `TEMPLATE_README.md` | テンプレート使い方（{{PLACEHOLDER}} 保持） |
| `docs/how-to/quickstart.md` | クイックスタート + Expo Go警告追加 |
| `docs/how-to/debug-guide.md` | デバッグガイド |
| `docs/how-to/sentry_setup.md` | Sentryセットアップ |
| `docs/how-to/screenshot-generation.md` | スクリーンショット生成 |
| `docs/how-to/store-listing-guide.md` | ストア掲載ガイド |
| `docs/store-listing/README.md` | ストア掲載アセット |
| `docs/reference/feature_spec_template.md` | 機能仕様テンプレート |
| `docs/reference/tasks/lessons.md` | 教訓の記録 |
| `scripts/store-screenshots/README.md` | スクショパイプライン |

### インデックス更新
| ファイル | 内容 |
|---------|------|
| `docs/README.md` | template-usage-guide.md エントリ追加 |

## Test plan

- [x] `pnpm verify` パス（lint, type-check, format, test 24件, i18n, config）
- [x] `{{PLACEHOLDER}}` が TEMPLATE_README.md に正しく保持されている
- [x] 全ファイルが日本語に翻訳されている

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)