### PR TITLE
feat(src): Repolog 汎用コードパターンを適用

### DIFF
--- a/src/core/i18n/i18n.ts
+++ b/src/core/i18n/i18n.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -23,6 +24,8 @@ import nl from './locales/nl';
 import pl from './locales/pl';
 import sv from './locales/sv';
 
+import { type Lang, normalizeLangCode } from './langCode';
+
 const dictionaries = {
   en: baseEn,
   ja,
@@ -45,45 +48,11 @@ const dictionaries = {
   sv,
 } satisfies Record<string, Partial<Record<TranslationKey, string>>>;
 
-export type Lang = keyof typeof dictionaries;
-
-const isSupportedLang = (code?: string): code is Lang => {
-  if (!code) return false;
-  return code in dictionaries;
-};
-
-const normalizeLang = (
-  rawCode?: string | null,
-  tag?: string | null,
-  script?: string | null,
-  region?: string | null,
-): Lang => {
-  if (rawCode && isSupportedLang(rawCode)) return rawCode;
-
-  const code = rawCode?.toLowerCase();
-  const tagLower = tag?.toLowerCase();
-  const regionUpper = region?.toUpperCase();
-
-  if (code === 'zh' || tagLower?.startsWith('zh')) {
-    const isHant =
-      tagLower?.includes('hant') ||
-      script === 'Hant' ||
-      (regionUpper != null && ['TW', 'HK', 'MO'].includes(regionUpper));
-    return isHant ? 'zhHant' : 'zhHans';
-  }
-
-  if (code === 'ms') return 'zhHans';
-
-  if (code && isSupportedLang(code)) return code;
-
-  return 'en';
-};
-
 const detectInitialLang = (): Lang => {
   try {
     const locales = Localization.getLocales();
     const primary = locales?.[0];
-    return normalizeLang(
+    return normalizeLangCode(
       primary?.languageCode,
       primary?.languageTag,
       primary?.languageScriptCode,
@@ -103,14 +72,14 @@ const useI18nStore = create<I18nState>()(
   persist(
     (set) => ({
       lang: detectInitialLang(),
-      setLang: (lang) => set({ lang: normalizeLang(lang) }),
+      setLang: (lang) => set({ lang: normalizeLangCode(lang) }),
     }),
     {
       name: 'app-i18n-lang',
       storage: createJSONStorage(() => AsyncStorage),
       onRehydrateStorage: () => (state) => {
         if (!state) return;
-        const normalized = normalizeLang(state.lang);
+        const normalized = normalizeLangCode(state.lang);
         if (state.lang !== normalized) {
           state.setLang(normalized);
         }
@@ -122,7 +91,8 @@ const useI18nStore = create<I18nState>()(
 export function useTranslation() {
   const lang = useI18nStore((s) => s.lang);
   const setLang = useI18nStore((s) => s.setLang);
-  const t = (key: TranslationKey) => dictionaries[lang][key] ?? baseEn[key] ?? key;
+  const dict = useMemo(() => ({ ...baseEn, ...dictionaries[lang] }), [lang]);
+  const t = useMemo(() => (key: TranslationKey) => dict[key] ?? key, [dict]);
   return { t, lang, setLang };
 }
 
@@ -144,4 +114,4 @@ export function t(key: TranslationKey) {
   return dictionaries[lang][key] ?? baseEn[key] ?? key;
 }
 
-export { TranslationKey };
+export { type Lang, TranslationKey };

--- a/src/core/i18n/langCode.ts
+++ b/src/core/i18n/langCode.ts
@@ -1,0 +1,53 @@
+const SUPPORTED_LANGS = [
+  'en',
+  'ja',
+  'fr',
+  'es',
+  'de',
+  'it',
+  'pt',
+  'ru',
+  'zhHans',
+  'zhHant',
+  'ko',
+  'hi',
+  'id',
+  'th',
+  'vi',
+  'tr',
+  'nl',
+  'pl',
+  'sv',
+] as const;
+
+export type Lang = (typeof SUPPORTED_LANGS)[number];
+
+export function isSupportedLang(code?: string): code is Lang {
+  if (!code) return false;
+  return (SUPPORTED_LANGS as readonly string[]).includes(code);
+}
+
+export function normalizeLangCode(
+  rawCode?: string | null,
+  tag?: string | null,
+  script?: string | null,
+  region?: string | null,
+): Lang {
+  if (rawCode && isSupportedLang(rawCode)) return rawCode;
+
+  const code = rawCode?.toLowerCase();
+  const tagLower = tag?.toLowerCase();
+  const regionUpper = region?.toUpperCase();
+
+  if (code === 'zh' || tagLower?.startsWith('zh')) {
+    const isHant =
+      tagLower?.includes('hant') ||
+      script === 'Hant' ||
+      (regionUpper != null && ['TW', 'HK', 'MO'].includes(regionUpper));
+    return isHant ? 'zhHant' : 'zhHans';
+  }
+
+  if (code && isSupportedLang(code)) return code;
+
+  return 'en';
+}

--- a/src/services/legalService.ts
+++ b/src/services/legalService.ts
@@ -6,22 +6,32 @@ export type LegalLinks = {
   termsUrl: string;
 };
 
-function getExtraValue(key: string): string {
-  const expoConfig = Constants.expoConfig ?? Constants.manifest;
-  const extra = (expoConfig as any)?.extra ?? {};
-  return (extra?.[key] as string) ?? '';
+const isHttpUrl = (value: string) => /^https?:\/\/\S+$/i.test(value);
+
+function resolveUrl(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  if (!trimmed || !isHttpUrl(trimmed)) return fallback;
+  return trimmed;
 }
 
-export function getLegalLinks(): LegalLinks {
+export function getLegalLinks(extra?: Record<string, unknown>): LegalLinks {
+  const resolved = extra ?? (Constants.expoConfig ?? (Constants.manifest as any))?.extra ?? {};
   return {
-    privacyUrl: getExtraValue('LEGAL_PRIVACY_URL') || 'https://example.com/privacy',
-    termsUrl: getExtraValue('LEGAL_TERMS_URL') || 'https://example.com/terms',
+    privacyUrl: resolveUrl(resolved['LEGAL_PRIVACY_URL'], 'https://example.com/privacy'),
+    termsUrl: resolveUrl(resolved['LEGAL_TERMS_URL'], 'https://example.com/terms'),
   };
 }
 
-export async function openExternalLink(url: string): Promise<void> {
-  const supported = await Linking.canOpenURL(url);
-  if (supported) {
-    await Linking.openURL(url);
+export async function openExternalLink(url: string): Promise<boolean> {
+  try {
+    const supported = await Linking.canOpenURL(url);
+    if (supported) {
+      await Linking.openURL(url);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
   }
 }

--- a/src/services/proService.ts
+++ b/src/services/proService.ts
@@ -9,7 +9,7 @@ import Purchases, {
   type PurchasesStoreProduct,
 } from 'react-native-purchases';
 
-import type { ProState } from '@/src/types/models';
+import type { PlanKind, ProState } from '@/src/types/models';
 import { IAP_DEBUG } from '@/src/core/debug';
 
 export type PlanType = 'monthly' | 'yearly' | 'lifetime';
@@ -54,25 +54,26 @@ async function saveState(state: ProState) {
   await SecureStore.setItemAsync(PRO_STATE_KEY, JSON.stringify(state));
 }
 
+function derivePlanType(productId: string | undefined, hasExpiration: boolean): PlanKind | null {
+  if (!productId) return null;
+  if (!hasExpiration) return 'lifetime';
+  const id = productId.toLowerCase();
+  if (id.includes('lifetime') || id.includes('lt')) return 'lifetime';
+  if (id.includes('annual') || id.includes('yearly') || id.includes('year')) return 'yearly';
+  if (id.includes('monthly') || id.includes('month')) return 'monthly';
+  return null;
+}
+
 function toProState(info: CustomerInfo): ProState {
   const entitlement = info.entitlements.active[ENTITLEMENT_ID];
   const isPro = Boolean(entitlement);
-
-  // Detect plan type from product identifier
-  // Conventions: *.monthly / *.yearly (or .annual) / *.lifetime
-  let planType: 'monthly' | 'yearly' | 'lifetime' | null = null;
-  if (entitlement) {
-    const productId = entitlement.productIdentifier?.toLowerCase() ?? '';
-    if (productId.includes('lifetime')) planType = 'lifetime';
-    else if (productId.includes('annual') || productId.includes('yearly')) planType = 'yearly';
-    else if (productId.includes('monthly')) planType = 'monthly';
-  }
-
   return {
     isPro,
     anonUserId: info.originalAppUserId ?? null,
     lastCheckAt: new Date().toISOString(),
-    planType,
+    planType: isPro
+      ? derivePlanType(entitlement?.productIdentifier, entitlement?.expirationDate != null)
+      : null,
     expirationDate: entitlement?.expirationDate ?? null,
     managementURL: info.managementURL ?? null,
   };
@@ -126,8 +127,6 @@ function findPackage(offering: PurchasesOffering | null, plan: PlanType): Purcha
   if (!offering) return null;
   if (plan === 'monthly') return offering.monthly;
   if (plan === 'yearly') return offering.annual;
-  // lifetime: RevenueCat exposes lifetime products via offering.lifetime
-  // OR via availablePackages with packageType === 'LIFETIME'
   if (offering.lifetime) return offering.lifetime;
   return offering.availablePackages?.find((p) => p.packageType === 'LIFETIME') ?? null;
 }
@@ -175,7 +174,27 @@ async function getPriceStrings(): Promise<{
   };
 }
 
+/** Exported for unit testing only. */
+export {
+  toProState as _toProState,
+  findPackage as _findPackage,
+  derivePlanType as _derivePlanType,
+};
+
 export const proService = {
+  addCustomerInfoListener(onUpdate: (state: ProState) => void): (() => void) | null {
+    if (!isNative) return null;
+    const handler = async (info: CustomerInfo) => {
+      const state = toProState(info);
+      await saveState(state);
+      onUpdate(state);
+    };
+    Purchases.addCustomerInfoUpdateListener(handler);
+    return () => {
+      Purchases.removeCustomerInfoUpdateListener(handler);
+    };
+  },
+
   async getPriceDetails() {
     return getPriceDetails();
   },

--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -3,6 +3,8 @@ import * as StoreReview from 'expo-store-review';
 import * as SecureStore from 'expo-secure-store';
 
 const REVIEW_STATE_KEY = 'app_review_state';
+const MAX_PROMPTS = 3;
+const COOLDOWN_DAYS = 90;
 
 type ReviewState = {
   lastPromptedAt: string | null;
@@ -23,37 +25,42 @@ async function saveState(state: ReviewState): Promise<void> {
   await SecureStore.setItemAsync(REVIEW_STATE_KEY, JSON.stringify(state));
 }
 
-/**
- * Request an in-app review if conditions are met:
- * - Native platform (iOS/Android)
- * - StoreReview is available
- * - Not prompted in the last 90 days
- * - Maximum 3 prompts total
- *
- * Call this at a positive moment (e.g. after completing a key action).
- */
-export async function maybeRequestReview(): Promise<boolean> {
-  if (Platform.OS === 'web') return false;
+export type ReviewDecision = 'prompt' | null;
 
-  const isAvailable = await StoreReview.isAvailableAsync();
-  if (!isAvailable) return false;
-
-  const state = await loadState();
-
-  if (state.promptCount >= 3) return false;
+export function shouldRequestReview(state: ReviewState): ReviewDecision {
+  if (state.promptCount >= MAX_PROMPTS) return null;
 
   if (state.lastPromptedAt) {
     const daysSince =
       (Date.now() - new Date(state.lastPromptedAt).getTime()) / (1000 * 60 * 60 * 24);
-    if (daysSince < 90) return false;
+    if (daysSince < COOLDOWN_DAYS) return null;
   }
 
-  await StoreReview.requestReview();
+  return 'prompt';
+}
 
-  await saveState({
-    lastPromptedAt: new Date().toISOString(),
-    promptCount: state.promptCount + 1,
-  });
+/**
+ * Call at a positive moment (e.g. after completing a key action).
+ * Fire-and-forget — errors never propagate to the caller.
+ */
+export async function maybeRequestReview(): Promise<void> {
+  try {
+    if (Platform.OS === 'web') return;
 
-  return true;
+    const isAvailable = await StoreReview.isAvailableAsync();
+    if (!isAvailable) return;
+
+    const state = await loadState();
+    const decision = shouldRequestReview(state);
+    if (!decision) return;
+
+    await StoreReview.requestReview();
+
+    await saveState({
+      lastPromptedAt: new Date().toISOString(),
+      promptCount: state.promptCount + 1,
+    });
+  } catch (e) {
+    console.warn('[ReviewPrompt] failed (non-fatal):', e);
+  }
 }

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+
+import type { PlanKind, ProState } from '@/src/types/models';
+import { proService, type PlanType } from '@/src/services/proService';
+
+type ProStore = {
+  state: ProState | null;
+  isPro: boolean;
+  planType: PlanKind | null;
+  expirationDate: string | null;
+  managementURL: string | null;
+  initialized: boolean;
+  busy: boolean;
+  init: () => Promise<void>;
+  refresh: () => Promise<void>;
+  purchase: (plan: PlanType) => Promise<ProState>;
+  restore: () => Promise<{ state: ProState; hasActive: boolean }>;
+};
+
+function spreadPlanFields(s: ProState) {
+  return {
+    isPro: s.isPro,
+    planType: s.planType ?? null,
+    expirationDate: s.expirationDate ?? null,
+    managementURL: s.managementURL ?? null,
+  };
+}
+
+export const useProStore = create<ProStore>((set, get) => ({
+  state: null,
+  isPro: false,
+  planType: null,
+  expirationDate: null,
+  managementURL: null,
+  initialized: false,
+  busy: false,
+  init: async () => {
+    if (get().initialized) return;
+    const local = await proService.loadLocalState();
+    if (local) {
+      set({ state: local, ...spreadPlanFields(local) });
+    }
+    set({ initialized: true });
+  },
+  refresh: async () => {
+    set({ busy: true });
+    try {
+      const state = await proService.refreshCustomerInfo();
+      if (state) {
+        set({ state, ...spreadPlanFields(state), initialized: true });
+      }
+    } finally {
+      set({ busy: false });
+    }
+  },
+  purchase: async (plan) => {
+    set({ busy: true });
+    try {
+      const state = await proService.purchase(plan);
+      set({ state, ...spreadPlanFields(state), initialized: true });
+      return state;
+    } finally {
+      set({ busy: false });
+    }
+  },
+  restore: async () => {
+    set({ busy: true });
+    try {
+      const result = await proService.restore();
+      set({ state: result.state, ...spreadPlanFields(result.state), initialized: true });
+      return result;
+    } finally {
+      set({ busy: false });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary

Repolog の実戦運用で確立された汎用コードパターンを app_template に適用。

- **proService.ts**: `derivePlanType()` を純粋関数として抽出、`addCustomerInfoListener()` でリアルタイム IAP 状態同期、テスト用エクスポート追加
- **legalService.ts**: URL バリデーション (`isHttpUrl`) 追加、`getLegalLinks()` に optional パラメータ、`openExternalLink()` が `boolean` を返すように変更
- **reviewService.ts**: 純粋決定関数 `shouldRequestReview()` を分離、`maybeRequestReview()` を fire-and-forget パターンに変更
- **proStore.ts** (新規): Zustand IAP 状態管理ストア（派生フィールド、`busy` フラグ）
- **langCode.ts** (新規): 言語コード正規化ロジックを i18n.ts から分離
- **i18n.ts**: `useTranslation()` の辞書マージを `useMemo` でメモ化

## Test plan

- [x] `pnpm lint` — pass
- [x] `pnpm type-check` — pass
- [x] `pnpm test` — 28 tests pass (3 suites)
- [ ] RevenueCat SDK はモック必須のため、リアルタイムリスナーの動作確認は実機で行う

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)